### PR TITLE
Add support for Paged Optimizers (Adam, Adamw), 8-bit optimizers, and new optimizers: LARS, LAMB and LION

### DIFF
--- a/ludwig/distributed/deepspeed.py
+++ b/ludwig/distributed/deepspeed.py
@@ -82,6 +82,10 @@ class DeepSpeedStrategy(DDPStrategy):
         batch_size = (
             trainer_config.batch_size if isinstance(trainer_config.batch_size, int) else MIN_POSSIBLE_BATCH_SIZE
         )
+        # Paged and 8-bit optimizers are not supported by Deepspeed - just whatever is supported
+        # by torch.optim.Optimizer. https://www.deepspeed.ai/docs/config-json/#optimizer-parameters.
+        if trainer_config.optimizer.is_paged or trainer_config.optimizer.is_8bit:
+            raise ValueError("Cannot use a paged or 8-bit optimizer with DeepSpeed.")
         optimizer_cls, optimizer_kwargs = get_optimizer_class_and_kwargs(trainer_config.optimizer, base_learning_rate)
         ds_config = {
             "amp": {

--- a/ludwig/modules/optimization_modules.py
+++ b/ludwig/modules/optimization_modules.py
@@ -65,5 +65,14 @@ def create_optimizer(
     :param optimizer_config: Instance of `ludwig.modules.optimization_modules.BaseOptimizerConfig`.
     :return: Initialized instance of a torch optimizer.
     """
+    # Make sure the optimizer is compatible with the available resources:
+    if (optimizer_config.is_paged or optimizer_config.is_8bit) and (
+        not torch.cuda.is_available() or torch.cuda.device_count() == 0
+    ):
+        raise ValueError(
+            "Cannot use a paged or 8-bit optimizer on a non-GPU machine. "
+            "Please use a different optimizer or run on a machine with a GPU."
+        )
+
     optimizer_cls, optimizer_kwargs = get_optimizer_class_and_kwargs(optimizer_config, learning_rate)
     return optimizer_cls(model.parameters(), **optimizer_kwargs)

--- a/ludwig/schema/optimizers.py
+++ b/ludwig/schema/optimizers.py
@@ -2,6 +2,7 @@ from abc import ABC
 from dataclasses import field
 from typing import ClassVar, Dict, Optional, Tuple, Type
 
+import bitsandbytes as bnb
 import torch
 from marshmallow import fields, ValidationError
 
@@ -50,6 +51,16 @@ class BaseOptimizerConfig(schema_utils.BaseMarshmallowConfig, ABC):
     a `ValidationError`.
     """
 
+    @property
+    def is_paged(self) -> bool:
+        """Returns True if the optimizer is a Paged optimizer."""
+        return False
+
+    @property
+    def is_8bit(self) -> bool:
+        """Returns True if the optimizer is an 8-bit optimizer."""
+        return False
+
 
 @DeveloperAPI
 @register_optimizer(name="sgd")
@@ -66,17 +77,55 @@ class SGDOptimizerConfig(BaseOptimizerConfig):
 
     # Defaults taken from https://pytorch.org/docs/stable/generated/torch.optim.SGD.html#torch.optim.SGD :
     momentum: float = schema_utils.NonNegativeFloat(
-        default=0.0, description="Momentum factor.", parameter_metadata=OPTIMIZER_METADATA["momentum"]
+        default=0.0,
+        description="Momentum factor.",
+        parameter_metadata=OPTIMIZER_METADATA["momentum"],
     )
+
     weight_decay: float = schema_utils.NonNegativeFloat(
-        default=0.0, description="Weight decay ($L2$ penalty).", parameter_metadata=OPTIMIZER_METADATA["weight_decay"]
+        default=0.0,
+        description="Weight decay ($L2$ penalty).",
+        parameter_metadata=OPTIMIZER_METADATA["weight_decay"],
     )
+
     dampening: float = schema_utils.NonNegativeFloat(
-        default=0.0, description="Dampening for momentum.", parameter_metadata=OPTIMIZER_METADATA["dampening"]
+        default=0.0,
+        description="Dampening for momentum.",
+        parameter_metadata=OPTIMIZER_METADATA["dampening"],
     )
+
     nesterov: bool = schema_utils.Boolean(
-        default=False, description="Enables Nesterov momentum.", parameter_metadata=OPTIMIZER_METADATA["nesterov"]
+        default=False,
+        description="Enables Nesterov momentum.",
+        parameter_metadata=OPTIMIZER_METADATA["nesterov"],
     )
+
+
+@DeveloperAPI
+@register_optimizer(name="sgd_8bit")
+@ludwig_dataclass
+class SGD8BitOptimizerConfig(SGDOptimizerConfig):
+    """Parameters for stochastic gradient descent."""
+
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.SGD8bit
+
+    type: str = schema_utils.ProtectedString("sgd_8bit")
+
+    block_wise: bool = schema_utils.Boolean(
+        default=False,
+        description="Whether to use block wise update.",
+    )
+
+    percentile_clipping: int = schema_utils.IntegerRange(
+        default=100,
+        min=0,
+        max=100,
+        description="Percentile clipping.",
+    )
+
+    @property
+    def is_8bit(self) -> bool:
+        return True
 
 
 @DeveloperAPI
@@ -170,6 +219,61 @@ class AdamOptimizerConfig(BaseOptimizerConfig):
 
 
 @DeveloperAPI
+@register_optimizer(name="adam_8bit")
+@ludwig_dataclass
+class Adam8BitOptimizerConfig(AdamOptimizerConfig):
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.Adam8bit
+
+    type: str = schema_utils.ProtectedString("adam_8bit")
+
+    block_wise: bool = schema_utils.Boolean(
+        default=True,
+        description="Whether to use block wise update.",
+    )
+
+    percentile_clipping: int = schema_utils.IntegerRange(
+        default=100,
+        min=0,
+        max=100,
+        description="Percentile clipping.",
+    )
+
+    @property
+    def is_8bit(self) -> bool:
+        return True
+
+
+@DeveloperAPI
+@register_optimizer(name="paged_adam")
+@ludwig_dataclass
+class PagedAdamOptimizerConfig(Adam8BitOptimizerConfig):
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.PagedAdam
+
+    type: str = schema_utils.ProtectedString("paged_adam")
+
+    @property
+    def is_paged(self) -> bool:
+        return True
+
+    @property
+    def is_8bit(self) -> bool:
+        return False
+
+
+@DeveloperAPI
+@register_optimizer(name="paged_adam_8bit")
+@ludwig_dataclass
+class PagedAdam8BitOptimizerConfig(PagedAdamOptimizerConfig):
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.PagedAdam8bit
+
+    type: str = schema_utils.ProtectedString("paged_adam_8bit")
+
+    @property
+    def is_8bit(self) -> bool:
+        return True
+
+
+@DeveloperAPI
 @register_optimizer(name="adamw")
 @ludwig_dataclass
 class AdamWOptimizerConfig(BaseOptimizerConfig):
@@ -205,6 +309,61 @@ class AdamWOptimizerConfig(BaseOptimizerConfig):
         "and Beyond'. ",
         parameter_metadata=OPTIMIZER_METADATA["amsgrad"],
     )
+
+
+@DeveloperAPI
+@register_optimizer(name="adamw_8bit")
+@ludwig_dataclass
+class AdamW8BitOptimizerConfig(AdamWOptimizerConfig):
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.AdamW8bit
+
+    type: str = schema_utils.ProtectedString("adamw_8bit")
+
+    block_wise: bool = schema_utils.Boolean(
+        default=True,
+        description="Whether to use block wise update.",
+    )
+
+    percentile_clipping: int = schema_utils.IntegerRange(
+        default=100,
+        min=0,
+        max=100,
+        description="Percentile clipping.",
+    )
+
+    @property
+    def is_8bit(self) -> bool:
+        return True
+
+
+@DeveloperAPI
+@register_optimizer(name="paged_adamw")
+@ludwig_dataclass
+class PagedAdamWOptimizerConfig(AdamW8BitOptimizerConfig):
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.PagedAdamW
+
+    type: str = schema_utils.ProtectedString("paged_adamw")
+
+    @property
+    def is_paged(self) -> bool:
+        return True
+
+    @property
+    def is_8bit(self) -> bool:
+        return False
+
+
+@DeveloperAPI
+@register_optimizer(name="paged_adamw_8bit")
+@ludwig_dataclass
+class PagedAdamW8BitOptimizerConfig(PagedAdamWOptimizerConfig):
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.PagedAdamW8bit
+
+    type: str = schema_utils.ProtectedString("paged_adamw_8bit")
+
+    @property
+    def is_8bit(self) -> bool:
+        return True
 
 
 @DeveloperAPI
@@ -272,6 +431,31 @@ class AdagradOptimizerConfig(BaseOptimizerConfig):
         description="Term added to the denominator to improve numerical stability.",
         parameter_metadata=OPTIMIZER_METADATA["eps"],
     )
+
+
+@DeveloperAPI
+@register_optimizer(name="adagrad_8bit")
+@ludwig_dataclass
+class Adagrad8BitOptimizerConfig(AdagradOptimizerConfig):
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.Adagrad8bit
+
+    type: str = schema_utils.ProtectedString("adagrad_8bit")
+
+    block_wise: bool = schema_utils.Boolean(
+        default=True,
+        description="Whether to use block wise update.",
+    )
+
+    percentile_clipping: int = schema_utils.IntegerRange(
+        default=100,
+        min=0,
+        max=100,
+        description="Percentile clipping.",
+    )
+
+    @property
+    def is_8bit(self) -> bool:
+        return True
 
 
 @DeveloperAPI
@@ -402,6 +586,259 @@ class RMSPropOptimizerConfig(BaseOptimizerConfig):
     )
 
     weight_decay: float = schema_utils.NonNegativeFloat(default=0.0, description="Weight decay ($L2$ penalty).")
+
+
+@DeveloperAPI
+@register_optimizer(name="rmsprop_8bit")
+@ludwig_dataclass
+class RMSProp8BitOptimizerConfig(RMSPropOptimizerConfig):
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.RMSprop8bit
+
+    type: str = schema_utils.ProtectedString("rmsprop_8bit")
+
+    block_wise: bool = schema_utils.Boolean(
+        default=True,
+        description="Whether to use block wise update.",
+    )
+
+    percentile_clipping: int = schema_utils.IntegerRange(
+        default=100,
+        min=0,
+        max=100,
+        description="Percentile clipping.",
+    )
+
+    @property
+    def is_8bit(self) -> bool:
+        return True
+
+
+@DeveloperAPI
+@register_optimizer(name="lamb")
+@ludwig_dataclass
+class LAMBOptimizerConfig(BaseOptimizerConfig):
+    """Layer-wise Adaptive Moments optimizer for Batch training.
+
+    Paper: https://arxiv.org/pdf/1904.00962.pdf
+    """
+
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.LAMB
+
+    type: str = schema_utils.ProtectedString("lamb")
+
+    bias_correction: bool = schema_utils.Boolean(
+        default=True,
+    )
+
+    betas: Tuple[float, float] = schema_utils.FloatRangeTupleDataclassField(
+        default=(0.9, 0.999),
+        description="Coefficients used for computing running averages of gradient and its square.",
+        parameter_metadata=OPTIMIZER_METADATA["betas"],
+    )
+
+    eps: float = schema_utils.NonNegativeFloat(
+        default=1e-08,
+        description="Term added to the denominator to improve numerical stability.",
+        parameter_metadata=OPTIMIZER_METADATA["eps"],
+    )
+
+    weight_decay: float = schema_utils.NonNegativeFloat(
+        default=0.0,
+        description="Weight decay (L2 penalty).",
+        parameter_metadata=OPTIMIZER_METADATA["weight_decay"],
+    )
+
+    amsgrad: bool = schema_utils.Boolean(
+        default=False,
+        description="Whether to use the AMSGrad variant of this algorithm from the paper 'On the Convergence of Adam "
+        "and Beyond'.",
+        parameter_metadata=OPTIMIZER_METADATA["amsgrad"],
+    )
+
+    adam_w_mode: bool = schema_utils.Boolean(
+        default=True,
+        description="Whether to use the AdamW mode of this algorithm from the paper "
+        "'Decoupled Weight Decay Regularization'.",
+    )
+
+    percentile_clipping: int = schema_utils.IntegerRange(
+        default=100,
+        min=0,
+        max=100,
+        description="Percentile clipping.",
+    )
+
+    block_wise: bool = schema_utils.Boolean(
+        default=False,
+        description="Whether to use block wise update.",
+    )
+
+    max_unorm: float = schema_utils.FloatRange(
+        default=1.0,
+        min=0.0,
+        max=1.0,
+    )
+
+
+@DeveloperAPI
+@register_optimizer(name="lamb_8bit")
+@ludwig_dataclass
+class LAMB8BitOptimizerConfig(LAMBOptimizerConfig):
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.LAMB8bit
+
+    type: str = schema_utils.ProtectedString("lamb_8bit")
+
+    @property
+    def is_8bit(self) -> bool:
+        return True
+
+
+@DeveloperAPI
+@register_optimizer(name="lars")
+@ludwig_dataclass
+class LARSOptimizerConfig(BaseOptimizerConfig):
+    """Layerwise Adaptive Rate Scaling.
+
+    Paper: https://arxiv.org/pdf/1708.03888.pdf
+    """
+
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.LARS
+
+    type: str = schema_utils.ProtectedString("lars")
+
+    # 0.9 taken from the original paper - momentum requires a non zero value
+    # https://arxiv.org/pdf/1708.03888v3.pdf
+    momentum: float = schema_utils.FloatRange(
+        default=0.9,
+        min=0.0,
+        max=1.0,
+        min_inclusive=False,
+        description="Momentum factor.",
+        parameter_metadata=OPTIMIZER_METADATA["momentum"],
+    )
+
+    dampening: float = schema_utils.FloatRange(
+        default=0.0,
+        min=0.0,
+        max=1.0,
+        description="Dampening for momentum.",
+        parameter_metadata=OPTIMIZER_METADATA["dampening"],
+    )
+
+    weight_decay: float = schema_utils.NonNegativeFloat(
+        default=0.0,
+        description="Weight decay (L2 penalty).",
+        parameter_metadata=OPTIMIZER_METADATA["weight_decay"],
+    )
+
+    nesterov: bool = schema_utils.Boolean(
+        default=False,
+        description="Enables Nesterov momentum.",
+        parameter_metadata=OPTIMIZER_METADATA["nesterov"],
+    )
+
+    percentile_clipping: int = schema_utils.IntegerRange(
+        default=100,
+        min=0,
+        max=100,
+        description="Percentile clipping.",
+    )
+
+    max_unorm: float = schema_utils.FloatRange(
+        default=1.0,
+        min=0.0,
+        max=1.0,
+    )
+
+
+@DeveloperAPI
+@register_optimizer(name="lars_8bit")
+@ludwig_dataclass
+class LARS8BitOptimizerConfig(LARSOptimizerConfig):
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.LARS8bit
+
+    type: str = schema_utils.ProtectedString("lars_8bit")
+
+    @property
+    def is_8bit(self) -> bool:
+        return True
+
+
+@DeveloperAPI
+@register_optimizer(name="lion")
+@ludwig_dataclass
+class LIONOptimizerConfig(BaseOptimizerConfig):
+    """Evolved Sign Momentum.
+
+    Paper: https://arxiv.org/pdf/2302.06675.pdf
+    """
+
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.Lion
+
+    type: str = schema_utils.ProtectedString("lion")
+
+    betas: Tuple[float, float] = schema_utils.FloatRangeTupleDataclassField(
+        default=(0.9, 0.999),
+        description="Coefficients used for computing running averages of gradient and its square.",
+        parameter_metadata=OPTIMIZER_METADATA["betas"],
+    )
+
+    weight_decay: float = schema_utils.NonNegativeFloat(
+        default=0.0,
+        description="Weight decay (L2 penalty).",
+        parameter_metadata=OPTIMIZER_METADATA["weight_decay"],
+    )
+
+    percentile_clipping: int = schema_utils.IntegerRange(
+        default=100,
+        min=0,
+        max=100,
+        description="Percentile clipping.",
+    )
+
+    block_wise: bool = schema_utils.Boolean(
+        default=True,
+        description="Whether to use block wise update.",
+    )
+
+
+@DeveloperAPI
+@register_optimizer(name="lion_8bit")
+@ludwig_dataclass
+class LION8BitOptimizerConfig(LIONOptimizerConfig):
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.Lion8bit
+
+    type: str = schema_utils.ProtectedString("lion_8bit")
+
+    @property
+    def is_8bit(self) -> bool:
+        return True
+
+
+@DeveloperAPI
+@register_optimizer(name="paged_lion")
+@ludwig_dataclass
+class PagedLionOptimizerConfig(LIONOptimizerConfig):
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.PagedLion
+
+    type: str = schema_utils.ProtectedString("paged_lion")
+
+    @property
+    def is_paged(self) -> bool:
+        return True
+
+
+@DeveloperAPI
+@register_optimizer(name="paged_lion_8bit")
+@ludwig_dataclass
+class PagedLion8BitOptimizerConfig(PagedLionOptimizerConfig):
+    optimizer_class: ClassVar[torch.optim.Optimizer] = bnb.optim.PagedLion8bit
+
+    type: str = schema_utils.ProtectedString("paged_lion_8bit")
+
+    @property
+    def is_8bit(self) -> bool:
+        return True
 
 
 @DeveloperAPI

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -57,6 +57,7 @@ from ludwig.utils.checkpoint_utils import Checkpoint, CheckpointManager
 from ludwig.utils.data_utils import load_json
 from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.fs_utils import path_exists
+from ludwig.utils.llm_utils import update_embedding_layer
 from ludwig.utils.metric_utils import get_metric_names, TrainerMetric
 from ludwig.utils.metrics_printed_table import print_metrics_table
 from ludwig.utils.misc_utils import set_random_seed
@@ -211,6 +212,8 @@ class Trainer(BaseTrainer):
             base_learning_rate *= lr_scale_fn(self.distributed.size())
         self.base_learning_rate = base_learning_rate
 
+        # We may need to replace the embedding layer when using 8-bit optimizers from bitsandbytes.
+        update_embedding_layer(self.compiled_model, self.config)
         self.dist_model, self.optimizer = self.distributed.prepare(
             self.compiled_model,
             self.config,

--- a/ludwig/utils/model_utils.py
+++ b/ludwig/utils/model_utils.py
@@ -74,3 +74,20 @@ def replace_tensors(m: torch.nn.Module, tensors: List[Dict], device: torch.devic
                 name,
                 torch.as_tensor(array, device=device, dtype=NUMPY_TO_TORCH_DTYPE.get(array.dtype)),
             )
+
+
+def find_embedding_layer_with_path(module, module_names=[]):
+    """Recursively search through a module to find an embedding layer and its module path.
+
+    Returns a tuple containing the embedding layer and its module path.
+    """
+    for name, child_module in module.named_children():
+        if isinstance(child_module, torch.nn.Embedding):
+            # If an embedding layer is found, return it along with the module path
+            return child_module, ".".join(module_names + [name])
+        else:
+            # Recursively search in the child module and update the module_names list
+            found, path = find_embedding_layer_with_path(child_module, module_names + [name])
+            if found is not None:
+                return found, path
+    return None, None

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,9 @@ sentencepiece
 # requirements for daft
 getdaft
 
+# requirement for various paged and 8-bit optimizers
+bitsandbytes<0.41.0
+
 # new data format support
 xlwt                # excel
 xlrd>=2.0.1         # excel

--- a/requirements_llm.txt
+++ b/requirements_llm.txt
@@ -3,5 +3,4 @@ faiss-cpu
 
 accelerate
 loralib
-bitsandbytes<0.41.0
 peft>=0.4.0

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -238,6 +238,16 @@ def test_resume_training_mlflow(optimizer, tmp_path):
 
 @pytest.mark.parametrize("optimizer_type", optimizer_registry)
 def test_optimizers(optimizer_type, tmp_path):
+    if (optimizer_type in {"lars", "lamb", "lion"}) and (
+        not torch.cuda.is_available() or torch.cuda.device_count() == 0
+    ):
+        pytest.skip("Skip: lars, lamb, and lion optimizers require GPU and none are available.")
+
+    if ("paged" in optimizer_type or "8bit" in optimizer_type) and (
+        not torch.cuda.is_available() or torch.cuda.device_count() == 0
+    ):
+        pytest.skip("Skip: paged and 8-bit optimizers require GPU and none are available.")
+
     input_features, output_features = synthetic_test_data.get_feature_configs()
 
     config = {


### PR DESCRIPTION
Recreated from original PR: https://github.com/ludwig-ai/ludwig/pull/3588

This PR adds support for a variety of new optimizers, including paged and 8-bit variants. All of these are useful for fine-tuning. I will add better descriptions for parameters in a follow-up PR when I better understand some of the underlying papers for LAMB, LARS and LION. I will also add tests once https://github.com/ludwig-ai/ludwig/pull/3578 PR lands.

# What are paged optimizers?

Paged Optimizers use NVIDIA unified memory 3 feature which does automatic page-to-page transfers between th...